### PR TITLE
A modification of POGame.getCopy() that allows to override the 'debug' flag in the copy (see comment)

### DIFF
--- a/core-extensions/SabberStoneCoreAi/src/POGame/POGame.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/POGame.cs
@@ -112,9 +112,9 @@ namespace SabberStoneCoreAi.POGame
 			game.Process(task);
 		}
 
-		public POGame getCopy()
+		public POGame getCopy(bool debug)
 		{
-			return new POGame(game, this.debug);
+			return new POGame(game, debug);
 		}
 
 


### PR DESCRIPTION
This pull request is just 1 simple commit that adds a parameter 'bool debug' to POGame.getCopy() which allows to override this parameter in a copy. If debug == true, then the copied state is fully printed which is not always wanted. The debug flag is stored privately in POGame so it could not be changed before this commit.