### PR TITLE
added tracking and output of exception stats

### DIFF
--- a/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
@@ -1,10 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 using SabberStoneCore.Enums;
 using SabberStoneCore.Model;
-using SabberStoneCore.Tasks.SimpleTasks;
 
 namespace SabberStoneCoreAi.POGame
 {
@@ -14,6 +12,8 @@ namespace SabberStoneCoreAi.POGame
 		private int nr_games = 0;
 		private int[] wins = new[] { 0, 0 };
 		private long[] time_per_player = new[] {0L, 0L};
+		private int[] exception_count = new[] {0, 0};
+		private List<string> exceptions = new List<string>();
 
 		//Todo add getter for each private variable
 
@@ -36,6 +36,19 @@ namespace SabberStoneCoreAi.POGame
 			time_per_player[1] += playerWatches[1].ElapsedMilliseconds;
 		}
 
+		public void registerException(Game game, Exception e)
+		{
+			if (game.Player1.PlayState == PlayState.CONCEDED)
+			{
+				exception_count[0] += 1;
+			}
+			else if (game.Player2.PlayState == PlayState.CONCEDED)
+			{
+				exception_count[1] += 1;
+			}
+			exceptions.Add(e.Message);
+		}
+
 		public void printResults()
 		{
 			if (nr_games > 0)
@@ -44,6 +57,16 @@ namespace SabberStoneCoreAi.POGame
 							  $"Avg. {(time_per_player[0] + time_per_player[1]) / nr_games} per game " +
 							  $"and {(time_per_player[0] + time_per_player[1]) / (nr_games * turns)} per turn!");
 				Console.WriteLine($"playerA {wins[0] * 100 / nr_games}% vs. playerB {wins[1] * 100 / nr_games}%!");
+				if (exceptions.Count > 0)
+				{
+					Console.WriteLine($"Games lost due to exceptions: playerA - {exception_count[0]}; playerB - {exception_count[1]}");
+					Console.WriteLine("Exception messages:");
+					foreach (var msg in exceptions)
+					{
+						Console.WriteLine($"\t{msg}");
+					}
+					Console.WriteLine();
+				}
 			} else
 			{
 				Console.WriteLine("No games played yet. Use Gamehandler.PlayGame() to add games.");

--- a/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
@@ -13,7 +13,7 @@ namespace SabberStoneCoreAi.POGame
 		private int[] wins = new[] { 0, 0 };
 		private long[] time_per_player = new[] {0L, 0L};
 		private int[] exception_count = new[] {0, 0};
-		private List<string> exceptions = new List<string>();
+		private Dictionary<int, string> exceptions = new Dictionary<int, string>();
 
 		//Todo add getter for each private variable
 
@@ -46,7 +46,7 @@ namespace SabberStoneCoreAi.POGame
 			{
 				exception_count[1] += 1;
 			}
-			exceptions.Add(e.Message);
+			exceptions.Add(nr_games, e.Message);
 		}
 
 		public void printResults()
@@ -61,9 +61,9 @@ namespace SabberStoneCoreAi.POGame
 				{
 					Console.WriteLine($"Games lost due to exceptions: playerA - {exception_count[0]}; playerB - {exception_count[1]}");
 					Console.WriteLine("Exception messages:");
-					foreach (var msg in exceptions)
+					foreach (var e in exceptions)
 					{
-						Console.WriteLine($"\t{msg}");
+						Console.WriteLine($"\tGame {e.Key}: {e.Value}");
 					}
 					Console.WriteLine();
 				}

--- a/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
@@ -98,5 +98,20 @@ namespace SabberStoneCoreAi.POGame
 			}
 		}
 
+		public int PlayerA_Exceptions
+		{
+			get
+			{
+				return this.exception_count[0];
+			}
+		}
+
+		public int PlayerB_Exceptions
+		{
+			get
+			{
+				return this.exception_count[1];
+			}
+		}
 	}
 }

--- a/core-extensions/SabberStoneCoreAi/src/POGame/POGameHandler.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/POGameHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using SabberStoneCore.Config;
 using SabberStoneCore.Enums;
@@ -6,7 +6,6 @@ using SabberStoneCore.Model;
 using SabberStoneCore.Model.Entities;
 using SabberStoneCore.Tasks;
 using SabberStoneCoreAi.Agent;
-using SabberStoneCoreAi.POGame;
 
 namespace SabberStoneCoreAi.POGame
 {
@@ -83,6 +82,9 @@ namespace SabberStoneCoreAi.POGame
 				game.State = State.COMPLETE;
 				game.CurrentPlayer.PlayState = PlayState.CONCEDED;
 				game.CurrentOpponent.PlayState = PlayState.WON;
+
+				if (addToGameStats && game.State != State.INVALID)
+					gameStats.registerException(game, e);
 			}
 
 			if (game.State == State.INVALID)


### PR DESCRIPTION
When testing I noticed games being lost due to exceptions. However, these don't get any different handling regarding the game stats. Thus, I added an additional output block when printing the game stats, which is only shown if at least one game was decided due to an agent throwing an exception.