### PR TITLE
Correct time tracking

### DIFF
--- a/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
@@ -11,7 +11,7 @@ namespace SabberStoneCoreAi.POGame
 		private int turns = 0;
 		private int nr_games = 0;
 		private int[] wins = new[] { 0, 0 };
-		private long[] time_per_player = new[] {0L, 0L};
+		private double[] time_per_player = new[] {0D, 0D};
 		private int[] exception_count = new[] {0, 0};
 		private Dictionary<int, string> exceptions = new Dictionary<int, string>();
 
@@ -32,8 +32,8 @@ namespace SabberStoneCoreAi.POGame
 			if (game.Player2.PlayState == PlayState.WON)
 				wins[1]++;
 
-			time_per_player[0] += playerWatches[0].ElapsedMilliseconds;
-			time_per_player[1] += playerWatches[1].ElapsedMilliseconds;
+			time_per_player[0] += playerWatches[0].Elapsed.TotalMilliseconds;
+			time_per_player[1] += playerWatches[1].Elapsed.TotalMilliseconds;
 		}
 
 		public void registerException(Game game, Exception e)

--- a/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
+++ b/core-extensions/SabberStoneCoreAi/src/POGame/GameStats.cs
@@ -53,9 +53,9 @@ namespace SabberStoneCoreAi.POGame
 		{
 			if (nr_games > 0)
 			{
-				Console.WriteLine($"{nr_games} games with {turns} turns took {time_per_player[0] + time_per_player[1]} ms => " +
-							  $"Avg. {(time_per_player[0] + time_per_player[1]) / nr_games} per game " +
-							  $"and {(time_per_player[0] + time_per_player[1]) / (nr_games * turns)} per turn!");
+				Console.WriteLine($"{nr_games} games with {turns} turns took {(time_per_player[0] + time_per_player[1]).ToString("F4")} ms => " +
+							  $"Avg. {((time_per_player[0] + time_per_player[1]) / nr_games).ToString("F4")} per game " +
+							  $"and {((time_per_player[0] + time_per_player[1]) / (nr_games * turns)).ToString("F8")} per turn!");
 				Console.WriteLine($"playerA {wins[0] * 100 / nr_games}% vs. playerB {wins[1] * 100 / nr_games}%!");
 				if (exceptions.Count > 0)
 				{


### PR DESCRIPTION
ElapsedMilliseconds from Stopwatch is of type long and doesn't contain any decimals
If the sum of the turns of a player take less than 1ms they are added as 0ms (e.g. in case of the random agent).
Also the avg per game and turn in printResults are printed correctly now because of these changes.